### PR TITLE
fix: add Windows compatibility to launcher script

### DIFF
--- a/bin/uberskills.mjs
+++ b/bin/uberskills.mjs
@@ -180,7 +180,7 @@ async function ensureInstalled(reset) {
   }
 
   await step("Cloning repository...", "Repository cloned", () =>
-    runQuiet(`git clone --depth 1 --branch v${VERSION} ${REPO_URL} ${APP_DIR}`),
+    runQuiet(`git clone --depth 1 --branch v${VERSION} ${REPO_URL} "${APP_DIR}"`),
   );
 
   await step("Enabling pnpm via corepack...", "Corepack enabled", async () => {
@@ -244,7 +244,7 @@ function printBanner(port, host, dataDir) {
 }
 
 // Launches the actual server as a child process after setup.
-// Binds stdio, propagates SIGINT/SIGTERM, sets environment (including database location and encryption).
+// Binds stdio, propagates SIGINT/SIGTERM (SIGTERM on Unix only), sets environment (including database location and encryption).
 function startServer(port, host, dataDir, encryptionSecret, debug) {
   const standaloneDir = join(APP_DIR, "apps", "web", ".next", "standalone");
   const serverScript = join("apps", "web", "server.js");
@@ -275,7 +275,7 @@ function startServer(port, host, dataDir, encryptionSecret, debug) {
     process.exit(code ?? 0);
   });
 
-  // Gracefully handle Ctrl+C (SIGINT) and termination (SIGTERM)
+  // Gracefully handle Ctrl+C (SIGINT) and termination (SIGTERM on Unix only — unsupported on Windows)
   const shutdown = () => {
     child.kill("SIGTERM");
   };

--- a/bin/uberskills.mjs
+++ b/bin/uberskills.mjs
@@ -19,11 +19,13 @@ const UBERSKILLS_HOME = join(homedir(), ".uberskills"); // Where all binaries, d
 const APP_DIR = join(UBERSKILLS_HOME, "app"); // Cloned app location
 const VERSION_FILE = join(UBERSKILLS_HOME, ".version"); // File to store installed version
 const PNPM_VERSION = "9.15.4"; // Explicit pnpm version for reproducible installs
+const isWindows = process.platform === "win32"; // Windows requires cmd.exe instead of sh
 
 // Run a command asynchronously with suppressed output. Resolves on success, rejects with stderr.
 function runQuiet(cmd, opts = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn("sh", ["-c", cmd], { stdio: "pipe", ...opts });
+    const [shell, shellFlag] = isWindows ? ["cmd.exe", "/c"] : ["sh", "-c"];
+    const child = spawn(shell, [shellFlag, cmd], { stdio: "pipe", ...opts });
     let stderr = "";
     child.stderr.on("data", (chunk) => {
       stderr += chunk.toString();
@@ -187,7 +189,7 @@ async function ensureInstalled(reset) {
   });
 
   await step("Installing dependencies...", "Dependencies installed", () =>
-    runQuiet("pnpm install --frozen-lockfile", { cwd: APP_DIR }),
+    runQuiet(`pnpm install --frozen-lockfile${isWindows ? " --shamefully-hoist" : ""}`, { cwd: APP_DIR }),
   );
 
   await step("Building application...", "Application built", () =>
@@ -279,7 +281,9 @@ function startServer(port, host, dataDir, encryptionSecret, debug) {
   };
 
   process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  if (!isWindows) {
+    process.on("SIGTERM", shutdown);
+  }
 }
 
 // ---


### PR DESCRIPTION
Fixes #64

## What

Four targeted changes to `bin/uberskills.mjs` to make the launcher work on native Windows (PowerShell / CMD) without requiring WSL or Git Bash.

## Why

The launcher unconditionally calls `spawn("sh", ["-c", cmd])` for all subprocess execution. On Windows, `sh` is not in the system PATH — it only exists in Git Bash / MSYS2 environments. Even inside Git Bash, Node.js's `spawn()` resolves binaries from the **Windows** environment PATH, so `sh` is never found.

Three additional issues surface once the shell problem is resolved:
- `pnpm install --frozen-lockfile` does not create `.bin` shims on Windows due to symlink permission restrictions, causing the build to fail with `'next' is not recognized`
- `process.on("SIGTERM")` is unsupported on Windows and throws at runtime
- Unquoted `APP_DIR` in the `git clone` command breaks when the Windows username contains spaces

## Changes

### 1. Cross-platform shell detection (`runQuiet`)
```js
// Before
const child = spawn("sh", ["-c", cmd], { stdio: "pipe", ...opts });

// After
const [shell, shellFlag] = isWindows ? ["cmd.exe", "/c"] : ["sh", "-c"];
const child = spawn(shell, [shellFlag, cmd], { stdio: "pipe", ...opts });
```

### 2. Windows-safe pnpm install
```js
// Before
runQuiet("pnpm install --frozen-lockfile", { cwd: APP_DIR })

// After
runQuiet(`pnpm install --frozen-lockfile${isWindows ? " --shamefully-hoist" : ""}`, { cwd: APP_DIR })
```
`--shamefully-hoist` forces pnpm to write real files instead of symlinks, which Windows restricts without Developer Mode or admin rights.

### 3. SIGTERM guard
```js
// Before
process.on("SIGINT", shutdown);
process.on("SIGTERM", shutdown);

// After
process.on("SIGINT", shutdown);
if (!isWindows) {
  process.on("SIGTERM", shutdown);
}
```

### 4. Quote APP_DIR in git clone command
```js
// Before
runQuiet(`git clone --depth 1 --branch v${VERSION} ${REPO_URL} ${APP_DIR}`)

// After
runQuiet(`git clone --depth 1 --branch v${VERSION} ${REPO_URL} "${APP_DIR}"`)
```
Without quotes, a username like `John Smith` causes `cmd.exe` to interpret `C:\Users\John` and `Smith\.uberskills\app` as separate arguments, breaking the clone silently.

## Testing

Confirmed working on:
- Windows 11 Pro (22H2), Node.js v22.20.0, PowerShell 7
- Full build succeeded: both `@uberskills/web` and `@uberskills/landing` built successfully
- Server started and served at `http://localhost:3000`

No behavior change on Linux/macOS — the `isWindows` flag is `false` and all existing code paths are unchanged.

## Checklist

- [x] Follows Conventional Commits format
- [x] No new dependencies introduced
- [x] No behavior change on Unix/macOS
- [x] Tested end-to-end on Windows 11