### PR TITLE
fix: make trigger field optional to support Claude Code skill format

### DIFF
--- a/apps/web/components/chat/skill-preview-panel.tsx
+++ b/apps/web/components/chat/skill-preview-panel.tsx
@@ -158,7 +158,7 @@ export function SkillPreviewPanel({ messages, isStreaming, onRegenerate }: Skill
       `---`,
       `name: "${frontmatter.name}"`,
       `description: "${frontmatter.description}"`,
-      `trigger: "${frontmatter.trigger}"`,
+      `trigger: "${frontmatter.trigger ?? ""}"`,
     ];
     if (frontmatter.model_pattern) {
       yamlLines.push(`model_pattern: "${frontmatter.model_pattern}"`);
@@ -187,7 +187,7 @@ export function SkillPreviewPanel({ messages, isStreaming, onRegenerate }: Skill
         body: JSON.stringify({
           name: nameOverride.trim() || frontmatter.name,
           description: frontmatter.description,
-          trigger: frontmatter.trigger,
+          trigger: frontmatter.trigger ?? "",
           modelPattern: frontmatter.model_pattern ?? null,
           content,
           tags: [],
@@ -350,7 +350,7 @@ export function SkillPreviewPanel({ messages, isStreaming, onRegenerate }: Skill
                 <dl className="space-y-2 text-sm">
                   <FrontmatterField label="Name" value={frontmatter.name} />
                   <FrontmatterField label="Description" value={frontmatter.description} />
-                  <FrontmatterField label="Trigger" value={frontmatter.trigger} />
+                  <FrontmatterField label="Trigger" value={frontmatter.trigger ?? ""} />
                   {frontmatter.model_pattern && (
                     <FrontmatterField
                       label="Model Pattern"

--- a/packages/skill-engine/src/generator.ts
+++ b/packages/skill-engine/src/generator.ts
@@ -13,8 +13,11 @@ export function generateSkillMd(frontmatter: SkillFrontmatter, content: string):
   const yamlData: Record<string, string> = {
     name: frontmatter.name,
     description: frontmatter.description,
-    trigger: frontmatter.trigger,
   };
+
+  if (frontmatter.trigger) {
+    yamlData.trigger = frontmatter.trigger;
+  }
 
   if (frontmatter.model_pattern != null && frontmatter.model_pattern !== "") {
     yamlData.model_pattern = frontmatter.model_pattern;

--- a/packages/skill-engine/src/validator.ts
+++ b/packages/skill-engine/src/validator.ts
@@ -126,8 +126,12 @@ export function validateSkill(frontmatter: SkillFrontmatter, content: string): V
   }
 
   if (isBlank(frontmatter.trigger)) {
-    errors.push({ field: "trigger", message: "Trigger is required.", severity: "error" });
-  } else if (XML_BRACKETS_PATTERN.test(frontmatter.trigger)) {
+    errors.push({
+      field: "trigger",
+      message: "Trigger is recommended for better skill discovery.",
+      severity: "warning",
+    });
+  } else if (XML_BRACKETS_PATTERN.test(frontmatter.trigger!)) {
     errors.push({
       field: "trigger",
       message: "Frontmatter fields must not contain XML angle brackets.",

--- a/packages/types/src/skill.ts
+++ b/packages/types/src/skill.ts
@@ -19,7 +19,7 @@ export type FileType = "script" | "reference";
 export interface SkillFrontmatter {
   name: string;
   description: string;
-  trigger: string;
+  trigger?: string;
   model_pattern?: string;
 }
 


### PR DESCRIPTION
Fixes #66

## What

Four targeted changes to make the `trigger` field optional when importing existing Claude Code skills.

## Why

Claude Code's SKILL.md format does not include a `trigger` field. It uses `description` to convey triggering conditions. When uberSKILLS imports any Claude Code skill, `trigger` is always empty, the validator always errors, and every skill is marked **Invalid** — with the import checkbox disabled.

This affects 100% of imported skills for every user who has existing Claude Code skills. There is no workaround from the UI.

## Changes

### `packages/types/src/skill.ts`
Make `trigger` optional in `SkillFrontmatter`:
```ts
trigger?: string;  // was: trigger: string
```

### `packages/skill-engine/src/validator.ts`
Downgrade `trigger` from `"error"` to `"warning"` severity. Non-blank triggers still get XML bracket validation:
```ts
// Before — hard error, blocks import
errors.push({ field: "trigger", message: "Trigger is required.", severity: "error" });

// After — advisory warning, import still works
errors.push({ field: "trigger", message: "Trigger is recommended for better skill discovery.", severity: "warning" });
```

### `packages/skill-engine/src/generator.ts`
Omit `trigger` from YAML output when empty (same pattern as `model_pattern`):
```ts
if (frontmatter.trigger) {
  yamlData.trigger = frontmatter.trigger;
}
```

### `apps/web/components/chat/skill-preview-panel.tsx`
Add `?? ""` fallback for three usages of `frontmatter.trigger` that expect `string`.

## Result

- Skills imported from Claude Code without a `trigger` field show a **warning** but are selectable and importable
- Skills with a `trigger` field are completely unaffected
- Skills created natively in uberSKILLS are still prompted to add a trigger via the warning

**Tested:** 29/31 Claude Code skills now import as Valid. The 2 remaining Invalid skills have legitimate errors (description exceeding 500 char limit) unrelated to this fix.

## Checklist

- [x] Follows Conventional Commits format
- [x] No new dependencies
- [x] No behavior change for skills with existing trigger fields
- [x] Tested end-to-end on Windows 11 with 31 real Claude Code skills